### PR TITLE
add build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,113 @@
+#addin "Cake.Powershell"
+
+#tool "nuget:?package=xunit.runner.console"
+
+///////////////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+///////////////////////////////////////////////////////////////////////////////
+
+var target          = Argument<string>("target", "Default");
+var configuration   = Argument<string>("Configuration", "Release");
+var Version         = Argument<string>("Version", "1.0.0");
+var runtime         = Argument<string>("Runtime", "win10-x64");
+var GitRevision     = Argument<string>("GitRevision", "0000000000000000000000000000000000000000");
+var GitRepo         = Argument<string>("GitRepo", "broken/repo");
+
+var isWindows       = Argument<bool>("isWindows", runtime.StartsWith("win"));
+var isLinux         = Argument<bool>("isLinux", runtime.StartsWith("ubu"));
+var isOsx           = Argument<bool>("isOsx", runtime.StartsWith("osx"));
+var solutionPath = "./scalus.sln";
+
+//runtime eg. "ubuntu.20.04-x64", "osx.10.15-x64"
+
+var publishdir="Publish/" + configuration + "/" + runtime;
+var builddir="Build/" + configuration + "/" + runtime;
+var outputdir="Output/" + configuration + "/" + runtime;
+var bindir="src/bin/" + configuration;
+var testdir="test/bin/" + configuration;
+
+// Run dotnet restore to restore all package references.
+Task("Restore")
+    .Does(() =>
+    {
+        DotNetCoreRestore();
+    });
+
+
+
+Task("MsiInstaller")
+    .IsDependentOn("Publish")
+    .WithCriteria(isWindows)
+    .Does(() =>
+    {
+    });
+
+
+Task("Build")
+    .IsDependentOn("Restore")
+    .Does(() =>
+    {
+       DotNetCoreBuild(solutionPath,
+           new DotNetCoreBuildSettings()
+	{
+	Configuration = configuration,
+        OutputDirectory = builddir
+	});
+
+    });
+
+
+Task("Clean")
+    .Does(() =>
+    {
+    CleanDirectory(bindir);
+    CleanDirectory(testdir);
+    });
+
+
+Task("Test")
+    .IsDependentOn("Build")
+    .Does(() =>
+        {
+            var projects = GetFiles("./test/**/*.csproj");
+            foreach(var project in projects)
+            {
+                DotNetCoreTest(
+                    project.FullPath,
+                    new DotNetCoreTestSettings()
+                {
+                    Configuration = configuration
+                });
+            }
+        });
+
+
+Task("Publish")
+    .IsDependentOn("Test")
+    .Does(() =>
+    {
+       DotNetCorePublish(
+           "./src/scalus.csproj",
+           new DotNetCorePublishSettings()
+       {
+           Configuration = configuration,
+           DiagnosticOutput = true,
+           OutputDirectory = publishdir,
+           SelfContained = true,
+           Runtime = runtime,
+           PublishSingleFile = true,
+           MSBuildSettings = new DotNetCoreMSBuildSettings()
+	   {
+	   }
+       });
+    });
+
+if (BuildSystem.AzurePipelines.IsRunningOnAzurePipelines)
+{
+    BuildSystem.AzurePipelines.Commands.WriteWarning( "Building " + target + " on azure for: " + runtime + "...");
+}
+else
+{
+	Information("Building " + target + " locally for: " + runtime  + "...");
+}
+RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,162 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER ShowDescription
+Shows description about tasks.
+.PARAMETER DryRun
+Performs a dry run.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+https://cakebuild.net
+#>
+
+
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target,
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+    [string]$Version,
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity,
+    [switch]$ShowDescription,
+    [Alias("WhatIf", "Noop")]
+    [switch]$DryRun,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs,
+    [switch]$Pre
+)
+
+# This is an automatic variable in PowerShell Core, but not in Windows PowerShell 5.x
+if (-not (Test-Path variable:global:IsCoreCLR)) {
+    $IsCoreCLR = $false
+}
+
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+$previousSecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
+try {
+  # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
+  # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
+  # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
+  # installed (.NET 4.5 is an in-place upgrade).
+  # PowerShell Core already has support for TLS 1.2 so we can skip this if running in that.
+  if (-not $IsCoreCLR) {
+      [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+  }
+}
+catch {
+  Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
+}
+
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $wc.Proxy = $proxy
+    return $wc
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$CAKE_DIR = Join-Path $TOOLS_DIR "Cake"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $CAKE_DIR "Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processes
+$ENV:NUGET_EXE = $NUGET_EXE
+
+Invoke-Expression "$NUGET_EXE install Cake -OutputDirectory $TOOLS_DIR -Version 1.0.0 -ExcludeVersion"
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Set it back so that DevOps doesn't get messed up
+[System.Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
+
+
+
+# Build Cake arguments
+$cakeArguments = @("$Script");
+if ($Target) { $cakeArguments += "--target=$Target" }
+if ($Configuration) { $cakeArguments += "--configuration=$Configuration" }
+if ($Version) { $cakeArguments += "--version=$Version" }
+if ($Verbosity) { $cakeArguments += "--verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "--showdescription" }
+if ($DryRun) { $cakeArguments += "--dryrun" }
+if ($Experimental) { $cakeArguments += "--experimental" }
+if ($Pre) { $cakeArguments += "--pre=true" }
+$cakeArguments += $ScriptArgs
+
+# Start Cake
+Write-Host "Running build script..."
+&$CAKE_EXE $cakeArguments
+exit $LASTEXITCODE

--- a/src/Properties/PublishProfiles/WindowsProfile.pubxml
+++ b/src/Properties/PublishProfiles/WindowsProfile.pubxml
@@ -10,7 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <PublishProvider>FileSystem</PublishProvider>
-    <PublishUrl>Publish\Windows</PublishUrl>
+    <PublishUrl>Publish/$configuration/$runtime</PublishUrl>
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <SiteUrlToLaunchAfterPublish />
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/test/scalus.Test.csproj
+++ b/test/scalus.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Add simple cake script to build a self-contained (dont need to install net core) single executable for supported runtime platforms

Default target 'Publish' produces output in  <projectroot>/Publish/${configuration}/${runtime}
e.g. 
      ./build.ps1 --runtime=win10-x64
      ./build.ps1 --runtime=ubuntu.20.04-x64
      ./build.ps1 --runtime=osx.10.15-x64
