### PR TITLE
create an rdp template that can handle rdp app or desktop

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   codeSigningCertFileName: 'OneIdentityCodeSigning.pfx'
-  signingToolPath: 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64'
+  signingToolPath: 'C:\Program Files (x86)\Windows Kits\10\App Certification Kit'
   isRelease: $[ startswith(variables['Build.SourceBranch'], 'refs/heads/release-')]
 
 jobs:

--- a/build.cake
+++ b/build.cake
@@ -328,7 +328,8 @@ Task("SignPath")
     			new SignToolSignSettings {
             		ToolPath = signTool,
             		CertPath = CertPath,
-            		Password = CertPass
+            		Password = CertPass,
+                        DigestAlgorithm = SignToolDigestAlgorithm.Sha256
     		});
     	});
 
@@ -341,7 +342,8 @@ Task("SignMsi")
     			new SignToolSignSettings {
             		ToolPath = signTool,
             		CertPath = CertPath,
-            		Password = CertPass
+            		Password = CertPass,
+                        DigestAlgorithm = SignToolDigestAlgorithm.Sha256
     		});
     	});
 

--- a/scripts/Win/Product.wxs
+++ b/scripts/Win/Product.wxs
@@ -32,6 +32,7 @@
 							<File Id="eg4" Source="$(var.tmpdir)\examples\rdp.remmina" />
 							<File Id="eg5" Source="$(var.tmpdir)\examples\ssh.remmina" />
 							<File Id="eg6" Source="$(var.tmpdir)\examples\RdpRemoteAppTemplate.rdp" />
+							<File Id="eg7" Source="$(var.tmpdir)\examples\WinRdpTemplate.rdp" />
 					</Component>
 					</Directory>
 				</Directory>

--- a/scripts/Win/scalus.json
+++ b/scripts/Win/scalus.json
@@ -2,7 +2,7 @@
   "Protocols": [
     {
       "Protocol": "rdp",
-      "AppId": "windows-rdp"
+      "AppId": "WindowsRDPDesktopOrApp"
     },
     {
       "Protocol": "ssh",
@@ -13,6 +13,29 @@
     }
   ],
   "Applications": [
+{
+      "id": "WindowsRDPDesktopOrApp",
+      "name": "WindowsRDPDesktopOrApp",
+      "description": "Run an RDP desktop session or an RDP remote app, using a template file",
+      "platforms": [
+        "Windows"
+      ],
+      "protocol": "rdp",
+      "parser": {
+        "parserId": "rdp",
+        "options": [
+          "waitforexit"
+        ],
+        "useDefaultTemplate": false,
+        "useTemplateFile": "%AppData%\\WinRdpTemplate.rdp",
+        "postProcessingExec": null,
+        "postProcessingArgs": null
+      },
+      "exec": "C:\\windows\\system32\\mstsc.exe",
+      "args": [
+        "%GeneratedFile%"
+      ]
+    },
     {
       "Id": "windows-rdp",
       "Description": "Run MS Windows RDP Client with a default connection file, which can be customized by the examplePlugin.pl perl script ",

--- a/scripts/examples/WinRdpTemplate.rdp
+++ b/scripts/examples/WinRdpTemplate.rdp
@@ -1,0 +1,35 @@
+alternate shell:s:%AlternateShell%
+audiocapturemode:i:%AlternateShell?1:0%
+authentication level:i:%AlternateShell?3:2%
+bitmapcachepersistenable:i:0
+compression:i:1
+connection type:i:7
+devicestoredirect:s:%AlternateShell?*:%
+drivestoredirect:s:%AlternateShell?*:%
+desktopheight:i:768
+desktopscalefactor:i:100
+desktopwidth:i:1024
+dynamic resolution:i:%AlternateShell?1:0%
+full address:s:%Host%
+gatewaycredentialssource:i:%AlternateShell?0:4%
+gatewayprofileusagemethod:i:0
+gatewayusagemethod:i:0
+promptcredentialonce:i:0
+prompt for credentials on client:i:0
+redirectclipboard:i:1
+redirectcomports:i:0
+redirectdrives:i:1
+redirectprinters:i:1
+redirectsmartcards:i:1
+remoteapplicationmode:i:%AlternateShell?1:0%
+remoteapplicationname:s:%Remoteapplicationname%
+remoteapplicationprogram:s:%Remoteapplicationprogram%
+screen mode id:i;1
+server port:i:3389
+smart sizing:i:%AlternateShell?0:1%
+span monitors:i:1
+use redirection server name:i:1
+use multimon:i:1
+username:s:%User%
+videoplaybackmode:i:1
+

--- a/scripts/examples/WinRdpTemplate.rdp
+++ b/scripts/examples/WinRdpTemplate.rdp
@@ -24,6 +24,7 @@ redirectsmartcards:i:1
 remoteapplicationmode:i:%AlternateShell?1:0%
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
+remoteapplicationcmdline:s:%Remoteapplicationcmdline%
 screen mode id:i;1
 server port:i:3389
 smart sizing:i:%AlternateShell?0:1%

--- a/src/Dto/Token.cs
+++ b/src/Dto/Token.cs
@@ -33,7 +33,8 @@ namespace scalus.Dto
             Remoteapplicationname=20,
             Remoteapplicationprogram=21,
             Account = 22,
-            Asset = 23
+            Asset = 23,
+            Remoteapplicationcmdline = 24
         };
 
         //processing options supported

--- a/src/Dto/Token.cs
+++ b/src/Dto/Token.cs
@@ -76,7 +76,8 @@ namespace scalus.Dto
             {Token.Remoteapplicationname, "The name of the remote application to run in the session."},
             {Token.Remoteapplicationprogram, "The alias or executable name of the remote application to run in the session."},
             {Token.Account, "The account part of a Safeguard URL." },
-            {Token.Asset, "The asset part of a Safeguard URL." }
+            {Token.Asset, "The asset part of a Safeguard URL." },
+            {Token.Remoteapplicationcmdline, "Optional command-line parameters for the remote application" }
         };
     }
 }

--- a/src/UrlParser/DefaultRdpUrlParser.cs
+++ b/src/UrlParser/DefaultRdpUrlParser.cs
@@ -287,12 +287,7 @@ namespace scalus.UrlParser
 
         public override string ReplaceTokens(string line)
         {
-            var newline = line;
-            foreach (var variable in Dictionary)
-            {
-                // TODO: Make this more robust. Edge case escapes don't work.
-                newline = Regex.Replace(newline, $"%{variable.Key}%", variable.Value ?? string.Empty, RegexOptions.IgnoreCase);
-            }
+            var newline = base.ReplaceTokens(line);
             var re = new Regex("(([^:]+):([^:]+):(.*))");
             var match = re.Match(newline);
 

--- a/src/UrlParser/DefaultRdpUrlParser.cs
+++ b/src/UrlParser/DefaultRdpUrlParser.cs
@@ -15,7 +15,7 @@ using System.IO;
 
 namespace scalus.UrlParser
 {
-    [ParserName("rdp")]  
+    [ParserName("rdp")]
     internal class DefaultRdpUrlParser : BaseParser
     {
         //This class parses an RDP string of the form
@@ -38,7 +38,7 @@ namespace scalus.UrlParser
         public Regex RdpPatt = new Regex("&");
 
         private readonly IDictionary<string, Tuple<bool, string>> _msArgList1 = new Dictionary<string, Tuple<bool, string>>();
-       
+
         private static string GetResource(string name)
         {
             var assembly = Assembly.GetExecutingAssembly();
@@ -56,16 +56,18 @@ namespace scalus.UrlParser
         }
 
 
-        
+
         public const string rdpPattern = "\\S=[s|i]:\\S+";
         public const string FullAddressKey = "full address";
         public const string UsernameKey = "username";
         public const string RdpPasswordHashKey = "password 51";
-        public const string AlternateShellKey = "alternate shell";
-        public const string RemoteapplicationnameKey = "remoteapplicationname";
-        public const string RemoteapplicationprogramKey = "remoteapplicationprogram";
+        public List<(string, Token)> RdpKeys = new List<(string, Token)> {
+            { ("alternate shell", Token.AlternateShell) },
+            { ("remoteapplicationname",Token.Remoteapplicationname ) },
+            { ("remoteapplicationprogram", Token.Remoteapplicationprogram) },
+            { ("remoteapplicationcmdline", Token.Remoteapplicationcmdline) }
+        };
 
-       
         public Dictionary<string, string> DefaultArgs = new Dictionary<string, string>();
 
        
@@ -181,9 +183,9 @@ namespace scalus.UrlParser
                 value = HttpUtility.UrlDecode(value);
                 if (name.Equals(UsernameKey))
                 {
-                    if ((value.IndexOf("%25", StringComparison.Ordinal) >= 0) || 
-                        (value.IndexOf("%5c", StringComparison.Ordinal)>= 0) ||
-                            (value.IndexOf("%20", StringComparison.Ordinal) >=0))
+                    if ((value.IndexOf("%25", StringComparison.Ordinal) >= 0) ||
+                        (value.IndexOf("%5c", StringComparison.Ordinal) >= 0) ||
+                            (value.IndexOf("%20", StringComparison.Ordinal) >= 0))
                     {
                         value = HttpUtility.UrlDecode(value);
                     }
@@ -194,7 +196,7 @@ namespace scalus.UrlParser
 
                     //Workaround a bug where 2 slashes were added to the connection URI instead of just 1
                     value = value.Replace("\\\\", "\\");
-                    
+
                     Dictionary[Token.User] = Regex.Replace(value, "^.:", "");
                     GetSafeguardUserValue(Dictionary);
                 }
@@ -204,7 +206,7 @@ namespace scalus.UrlParser
 
                     (string host, string port) = ParseHost(Regex.Replace(hostval, "^.:", ""));
                     Dictionary[Token.Host] = host;
-                    
+
                     if (!string.IsNullOrEmpty(port))
                     {
                         Dictionary[Token.Port] = port;
@@ -213,22 +215,19 @@ namespace scalus.UrlParser
                     {
                         Dictionary[Token.Port] = "3389";
                     }
-                }              
+                }
                 else
                 {
                     value = HttpUtility.UrlDecode(value);
-                }
-                if (Regex.IsMatch(name, AlternateShellKey))
-                {
-                    Dictionary[Token.AlternateShell] = value;
-                }
-                else if (Regex.IsMatch(name, RemoteapplicationnameKey))
-                {
-                    Dictionary[Token.Remoteapplicationname] = value;
-                }
-                else if (Regex.IsMatch(name, RemoteapplicationprogramKey))
-                {
-                    Dictionary[Token.Remoteapplicationprogram] = value;
+
+                    foreach (var one in RdpKeys)
+                    {
+                        if (Regex.IsMatch(name, one.Item1))
+                        {
+                            Dictionary[one.Item2] = value;
+                            break;
+                        }
+                    }
                 }
                 _msArgList1[name] = Tuple.Create(true, type + ":" + value);
             }

--- a/test/TestDefaultRdpUrlParser.cs
+++ b/test/TestDefaultRdpUrlParser.cs
@@ -327,6 +327,7 @@ namespace scalus.Test
             const string url2 = "rdp://alternate+shell:s:%7C%7COISGRemoteAppLauncher%20%281%29";
             const string url3 = "rdp://alternate+shell=s:%7C%7COISGRemoteAppLauncher%20%281%29&remoteapplicationprogram:s:%7C%7COISGRemoteAppLauncher%20%281%29&remoteapplicationname:s:Test%20Application&full+address=s:10.5.33.211&username=s:dan.vas%5caccount%7edbuser%25asset%7eTest%20Application%25vaultaddress%7e10.5.34.63%25token%7e9ttSPCSNYvJwwE7YajAPJgRF3MbL1YCxvRUk17RT6rEGSHCDWN4vwKNExxnxXjHPMmEBrZMy9N4XWWaqE2%25bnicholes%2510.5.37.71/";
             const string url4 = "rdp://alternate+shell=s:%7C%7COISGRemoteAppLauncher%20%281%29";
+            const string url5 = "rdp://alternate+shell=s:%7C%7COISGRemoteAppLauncher%20%281%29&remoteapplicationprogram=s:%7C%7COISGRemoteAppLauncher%20%281%29&remoteapplicationname=s:Test%20Application&full+address=s:10.5.33.211&username=s:dan.vas%5caccount%7edbuser%25asset%7eTest%20Application%25vaultaddress%7e10.5.34.63%25token%7e3Ft3PPjupF89gV5nADGTBJGTYEGArt2tvTCVA24T1pVF5Mq2QpRiePEQM6JupHrMzj6eY81CpfSeircRk%25bnicholes%2510.5.37.71/";
             using (var sut = new DefaultRdpUrlParser(new Dto.ParserConfig()))
             {
                 var dictionary = sut.Parse(url1);
@@ -348,6 +349,14 @@ namespace scalus.Test
                 dictionary = sut.Parse(url4);
                 Assert.Equal("rdp", dictionary[Token.Protocol]);
                 Assert.Equal("||OISGRemoteAppLauncher (1)", dictionary[Token.AlternateShell]);
+
+                dictionary = sut.Parse(url5);
+                Assert.Equal("rdp", dictionary[Token.Protocol]);
+                Assert.Equal("Test Application", dictionary[Token.Remoteapplicationname]);
+                Assert.Equal("||OISGRemoteAppLauncher (1)", dictionary[Token.Remoteapplicationprogram]);
+                Assert.Equal("||OISGRemoteAppLauncher (1)", dictionary[Token.AlternateShell]);
+
+
             }
         }
     }

--- a/test/TestLaunchArgs.cs
+++ b/test/TestLaunchArgs.cs
@@ -57,6 +57,12 @@ namespace scalus.Test
                 { Token.TempPath, Path.GetTempPath() },
                 { Token.Home, "homedir" },
                 { Token.AppData, "appdata/scalus"},
+                { Token.AlternateShell, "myshell" },
+                { Token.Remoteapplicationname, "myname" },
+                { Token.Remoteapplicationprogram, "myprogram" },
+                { Token.Account, "myaccount" },
+                { Token.Asset, "myasset" },
+                { Token.Remoteapplicationcmdline, "--cmd \"C:\\Apps\\TestRemoteApp\\TestRemoteApp.exe\" --args \"password={password} asset={asset} user={username}\" --enable-debug" }
             };
         }
 
@@ -85,7 +91,14 @@ namespace scalus.Test
                 $"%{Token.GeneratedFile}%",
                 $"%{Token.TempPath}%",
                 $"%{Token.Home}%",
-                $"%{Token.AppData}%"
+                $"%{Token.AppData}%",
+
+                $"%{ Token.AlternateShell}%",
+                $"%{ Token.Remoteapplicationname}%",
+                $"%{ Token.Remoteapplicationprogram}%",
+                $"%{ Token.Account}%",
+                $"%{ Token.Asset}%",
+                $"%{ Token.Remoteapplicationcmdline }%"
             };
                
             
@@ -127,6 +140,21 @@ namespace scalus.Test
             Assert.Equal("homedir", one.Current);
             Assert.True(one.MoveNext());
             Assert.Equal("appdata/scalus", one.Current);
+
+
+            Assert.True(one.MoveNext());
+            Assert.Equal("myshell", one.Current);
+            Assert.True(one.MoveNext());
+            Assert.Equal("myname", one.Current);
+            Assert.True(one.MoveNext());
+            Assert.Equal("myprogram", one.Current);
+            Assert.True(one.MoveNext());
+            Assert.Equal("myaccount", one.Current);
+            Assert.True(one.MoveNext());
+            Assert.Equal("myasset", one.Current);
+            Assert.True(one.MoveNext());
+            Assert.Equal("--cmd \"C:\\Apps\\TestRemoteApp\\TestRemoteApp.exe\" --args \"password={password} asset={asset} user={username}\" --enable-debug", one.Current);
+
             Assert.False(one.MoveNext());
 
             args = new List<string>

--- a/test/TestLaunchArgs.cs
+++ b/test/TestLaunchArgs.cs
@@ -56,7 +56,7 @@ namespace scalus.Test
                 { Token.GeneratedFile, filename },
                 { Token.TempPath, Path.GetTempPath() },
                 { Token.Home, "homedir" },
-                {Token.AppData, "appdata/scalus"}
+                { Token.AppData, "appdata/scalus"},
             };
         }
 
@@ -154,7 +154,27 @@ namespace scalus.Test
             Assert.False(one.MoveNext());
             }
         }
+        [Fact]
+        public void TestComplexParse()
+        {
+            var line = $"start %{Token.AlternateShell}% mid1 %{Token.AlternateShell}?shell1:shell2%  %{Token.Host}%  sometext%{Token.Host}?:% mid2 line%{Token.AlternateShell}?shell3:% %{Token.Host}?host1:%    %{Token.Host}?:host2%   %{Token.Host}?host3:host4%   %{Token.AlternateShell}?:shell4%";
+            var exp1 = $"start %{Token.AlternateShell}% mid1 %{Token.AlternateShell}?shell1:shell2%  {host}  sometext mid2 line%{Token.AlternateShell}?shell3:% host1       host3   %{Token.AlternateShell}?:shell4%";
+            var exp2 = $"start  mid1 shell2  {host}  sometext mid2 line host1       host3   shell4";
+            var exp3 = $"start aaaaa mid1 shell1  {host}  sometext mid2 lineshell3 host1       host3   ";
 
+            var newline = BaseParser.ReplaceToken(Token.User.ToString(), "abc", line);
+            Assert.Equal(line, newline);
+
+            newline = BaseParser.ReplaceToken(Token.Host.ToString(), host, line);
+            Assert.Equal(exp1, newline);
+
+            newline = BaseParser.ReplaceToken(Token.AlternateShell.ToString(), "", exp1);
+            Assert.Equal(exp2, newline);
+
+            newline = BaseParser.ReplaceToken(Token.AlternateShell.ToString(), "aaaaa", exp1);
+            Assert.Equal(exp3, newline);
+
+        }
         [Fact]
         public void Test2()
         {


### PR DESCRIPTION
Add the remoteapplicationcmdline token.

Some of the RDP file properties need different values depending on whether the URL is for a full desktop session or running a remote app.  To allow for this provide some flexibility in the template file,  by allowing values depending on the value of a token, ie 

%_Token_ ? _truevalue_ : _falsevalue_ %          


e.g.   to set the remoteapplicationmode to 1 only if the AlternateShell token has a value:    

`remoteapplicationmode:i:%AlternateShell?1:0%
`