### PR TITLE
Updating the SCALUS project to .NET 8 as .NET 6 has reached its End of support

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -174,6 +174,7 @@ Task("MsiInstaller")
         WiXLight(wobjFiles, new LightSettings
         {
             Extensions = new[] { "WixUIExtension", "WixUtilExtension" },
+            RawArguments = "-sice:ICE61",
             OutputFile = msiPath
         });
 
@@ -201,8 +202,9 @@ Task("Build")
             new DotNetBuildSettings()
             {
                 Configuration = configuration,
-                OutputDirectory = builddir,
+                //OutputDirectory = builddir,
                 MSBuildSettings = new DotNetMSBuildSettings()
+                    .WithProperty("OutputPath", builddir)
                     .WithProperty("Edition", edition)
             });
     });

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin "Cake.Powershell&version=2.0.0"
+#addin "Cake.Powershell&version=2.0.0&loaddependencies=true"
 #tool "nuget:?package=xunit.runner.console&version=2.4.2"
 #tool "nuget:?package=WiX&version=3.11.2"
 #addin nuget:?package=SharpZipLib&version=1.4.0

--- a/scripts/examples/RdpRemoteAppTemplate.rdp
+++ b/scripts/examples/RdpRemoteAppTemplate.rdp
@@ -3,7 +3,7 @@ alternate shell:s:%AlternateShell%
 audiocapturemode:i:1
 devicestoredirect:s:*
 drivestoredirect:s:*
-full address:s:%Host%
+full address:s:%Host%:%Port%
 gatewayusagemethod:i:0
 gatewayprofileusagemethod:i:1
 gatewaycredentialssource:i:0
@@ -19,7 +19,7 @@ redirectdrives:i:1
 remoteapplicationmode:i:1
 remoteapplicationprogram:s:%Remoteapplicationprogram%
 remoteapplicationname:s:%Remoteapplicationname%
-server port:i:3389
+server port:i:%Port%
 session bpp:i:32
 span monitors:i:1
 use redirection server name:i:1

--- a/scripts/examples/WinRdpTemplate.rdp
+++ b/scripts/examples/WinRdpTemplate.rdp
@@ -26,7 +26,7 @@ remoteapplicationmode:i:%AlternateShell?1:0%
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
 remoteapplicationcmdline:s:%Remoteapplicationcmdline%
-screen mode id:i;1
+screen mode id:i:1
 server port:i:3389
 smart sizing:i:%AlternateShell?0:1%
 span monitors:i:1

--- a/scripts/examples/WinRdpTemplate.rdp
+++ b/scripts/examples/WinRdpTemplate.rdp
@@ -10,7 +10,7 @@ desktopheight:i:768
 desktopscalefactor:i:100
 desktopwidth:i:1024
 dynamic resolution:i:%AlternateShell?1:0%
-full address:s:%Host%
+full address:s:%Host%:%Port%
 gatewaycredentialssource:i:%AlternateShell?0:4%
 gatewayprofileusagemethod:i:0
 gatewayusagemethod:i:0
@@ -27,7 +27,7 @@ remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
 remoteapplicationcmdline:s:%Remoteapplicationcmdline%
 screen mode id:i:1
-server port:i:3389
+server port:i:%Port%
 smart sizing:i:%AlternateShell?0:1%
 span monitors:i:1
 use redirection server name:i:1

--- a/scripts/examples/examplePlugin.pl
+++ b/scripts/examples/examplePlugin.pl
@@ -33,11 +33,15 @@ open(DATA, "<${filename}") or die "ERROR:Couldnt open file ${filename}, $!";
 open(TOFILE, ">${tmpfile}") or die "ERROR:Couldnt open file ${tmpfile}, $!";
 while (<DATA>){
 	chomp;
-	my ($key, $valtype, $val) = split /:/, $_;
-	if (not (exists $settings{$key})) {
-		if (($key ne "password 51") or ($spass == ""))
+	my @keyval = split /:/, $_;
+	if (not (exists $settings{$keyval[0]})) {
+		if (($keyval[0] ne "password 51") or ($spass == ""))
 		{
-			$settings{$key} = "${valtype}:${val}";
+			$settings{$keyval[0]} = "$keyval[1]:$keyval[2]";
+			if ((lc($keyval[0]) eq "full address") and ($keyval[3] ne ""))
+			{
+				$settings{$keyval[0]} = "$keyval[1]:$keyval[2]:$keyval[3]";
+			}
 		} 
 	}
 

--- a/scripts/examples/exampleRdpTemplate.rdp
+++ b/scripts/examples/exampleRdpTemplate.rdp
@@ -58,7 +58,7 @@ remoteapplicationicon:s:
 remoteapplicationmode:i:0
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
-screen mode id:i;1
+screen mode id:i:1
 selectedmonitors:s:
 server port:i:3389
 session bpp:i:32

--- a/scripts/examples/exampleRdpTemplate.rdp
+++ b/scripts/examples/exampleRdpTemplate.rdp
@@ -29,7 +29,7 @@ dynamic resolution:i:0
 enablecredsspsupport:i:1
 enableworkspacereconnect:i:0
 encode redirected video capture:i:1
-full address:s:%Host%
+full address:s:%Host%:%Port%
 gatewaybrokeringtype:i:0
 gatewaycredentialssource:i:4
 gatewayhostname:s:
@@ -60,7 +60,7 @@ remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
 screen mode id:i:1
 selectedmonitors:s:
-server port:i:3389
+server port:i:%Port%
 session bpp:i:32
 shell working directory:s:
 singlemoninwindowedmode:i:0

--- a/src/OneIdentity.Scalus.csproj
+++ b/src/OneIdentity.Scalus.csproj
@@ -10,14 +10,14 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>OneIdentity.Scalus</RootNamespace>
     <AssemblyName>scalus</AssemblyName>
     <StartupObject>OneIdentity.Scalus.Program</StartupObject>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>signer.pfx</AssemblyOriginatorKeyFile>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
-    <RuntimeIdentifiers>linux-x64;osx-x64;win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;osx-x64;win-x64</RuntimeIdentifiers>
     <UserSecretsId>dc8f57ba-8a9d-40c4-bf34-a2ffba1ff687</UserSecretsId>
     <Company>One Identity LLC</Company>
     <Copyright>Copyright 2021 One Identity LLC</Copyright>
@@ -38,11 +38,11 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;CA1854;CA1859;CA1860;CA1865;SYSLIB1045;SYSLIB1054</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;CA1416</NoWarn>
+    <NoWarn>1701;1702;CA1416;CA1854;CA1859;CA1860;CA1865;SYSLIB1045;SYSLIB1054</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ScalusConfiguration.cs
+++ b/src/ScalusConfiguration.cs
@@ -40,7 +40,7 @@ namespace OneIdentity.Scalus
         {
             Serilog.Log.Information($"Checking configuration for url:{uri}");
             // var manually parse out the protocol
-            var index = uri.IndexOf("://");
+            var index = uri.IndexOf("://", StringComparison.Ordinal);
             var protocol = string.Empty;
             if (index >= 0)
             {

--- a/test/OneIdentity.Scalus.Test.csproj
+++ b/test/OneIdentity.Scalus.Test.csproj
@@ -4,14 +4,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>signer.pfx</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <OutputType>WinExe</OutputType>
     <RootNamespace>OneIdentity.Scalus.Test</RootNamespace>
-    <RuntimeIdentifiers>linux-x64;osx-x64;win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;osx-x64;win-x64</RuntimeIdentifiers>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
@@ -20,11 +20,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702</NoWarn>
+    <NoWarn>1701;1702;CA1854;CA1859;CA1860;CA1865;SYSLIB1045;SYSLIB1054</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702</NoWarn>
+    <NoWarn>1701;1702;CA1854;CA1859;CA1860;CA1865;SYSLIB1045;SYSLIB1054</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Updates Summary
- Updated the SCALUS project to .NET 8 
- Updated build.cake to clear warnings and error messages encountered during the build process
- Updated RDP templates and the Perl post-processing script to support custom RDP port
- Included a fix to address issue specific to the Thai language