### PR TITLE
Fix Typo for Screen Mode ID

### DIFF
--- a/scripts/examples/WinRdpTemplate.rdp
+++ b/scripts/examples/WinRdpTemplate.rdp
@@ -26,7 +26,7 @@ remoteapplicationmode:i:%AlternateShell?1:0%
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
 remoteapplicationcmdline:s:%Remoteapplicationcmdline%
-screen mode id:i;1
+screen mode id:i:1
 server port:i:3389
 smart sizing:i:%AlternateShell?0:1%
 span monitors:i:1

--- a/scripts/examples/exampleRdpTemplate.rdp
+++ b/scripts/examples/exampleRdpTemplate.rdp
@@ -58,7 +58,7 @@ remoteapplicationicon:s:
 remoteapplicationmode:i:0
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
-screen mode id:i;1
+screen mode id:i:1
 selectedmonitors:s:
 server port:i:3389
 session bpp:i:32

--- a/src/Resources/Default.rdp
+++ b/src/Resources/Default.rdp
@@ -58,7 +58,7 @@ remoteapplicationicon:s:
 remoteapplicationmode:i:0
 remoteapplicationname:s:%Remoteapplicationname%
 remoteapplicationprogram:s:%Remoteapplicationprogram%
-screen mode id:i;1
+screen mode id:i:1
 selectedmonitors:s:
 server port:i:3389
 session bpp:i:32


### PR DESCRIPTION
The "screen mode id" parameter in all of the .rdp files had a typo that used a semi-colon instead of a colon as a separator.